### PR TITLE
Fix encoding issue and 7zip issue

### DIFF
--- a/enhance-dictionary.pl
+++ b/enhance-dictionary.pl
@@ -333,7 +333,7 @@ sub unpack_original_glohd {
   if (! $opt_jadict) {
     die "Cannot determine abs path of $opt_jadict: $?";
   }
-  `cd $orig ; LC_CTYPE=C 7z x \"$opt_jadict\"`;
+  `cd $orig ; LC_CTYPE=C 7z x -y \"$opt_jadict\"`;
   print "done\n";
 }
 

--- a/enhance-dictionary.pl
+++ b/enhance-dictionary.pl
@@ -260,7 +260,7 @@ sub load_edict {
   $edict{'__TYPE'} = 'edict2';
   $edict{'__FILE'} = $edict;
   $edict{'__USED'} = 0;
-  open (my $wf, '<:encoding(utf8)', $edict) or die "Cannot open $edict: $?";
+  open (my $wf, '<:encoding(euc-jp)', $edict) or die "Cannot open $edict: $?";
   print "loading edict2 type from $edict ... ";
   my $line = 0;
   while (<$wf>) {


### PR DESCRIPTION
Fix for the encoding issue that give errors while reading the edict2 file:
![screen shot 2019-02-05 at 20 29 01](https://user-images.githubusercontent.com/28924027/52299335-6e558b80-2985-11e9-9790-2ce2cf624d6c.png)
and the issue that makes the script hang because 7zip expects input:
![screen shot 2019-02-05 at 20 30 05](https://user-images.githubusercontent.com/28924027/52299372-82998880-2985-11e9-8b71-236eb6aca58c.png)
After these fixes the script works as intended:
![screen shot 2019-02-05 at 20 31 32](https://user-images.githubusercontent.com/28924027/52299393-8decb400-2985-11e9-9ee8-e84304e4cfd3.png)



